### PR TITLE
Update platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@ lib_deps =
     jled
 
 env_default = d1_mini
-build_flags = 
+build_flags = -DIOTWEBCONF_PASSWORD_LEN=65
 lib_ldf_mode = deep+
 
 [env:d1_mini]


### PR DESCRIPTION
Solve password length is limited to 32 charters problem with iotwebconf.

Edit: https://github.com/prampec/IotWebConf/issues/196#issuecomment-851879964