### PR TITLE
Add Support for ESP32 Ethernet and ESP32 Serial Devices

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -51,3 +51,12 @@ build_flags = ${common.build_flags} -DSERIAL_DEBUG=true -DSERIAL_DEBUG_VERBOSE=f
 upload_port = /dev/ttyUSB0
 monitor_port = /dev/ttyUSB0
 monitor_speed = 115200
+
+[env:esp32-poe]
+platform = espressif32
+board = esp32-poe
+framework = arduino
+lib_deps = ${common.lib_deps}
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags} -DSERIAL_DEBUG=true -DSERIAL_DEBUG_VERBOSE=false
+monitor_speed = 115200

--- a/src/MqttPublisher.h
+++ b/src/MqttPublisher.h
@@ -203,13 +203,11 @@ private:
     client.onDisconnect([this](AsyncMqttClientDisconnectReason reason) {
       this->connected = false;
       DEBUG(F("MQTT: Disconnected. Reason: %d."), reason);
-#ifndef ESP32_ETH
-      reconnectTimer.attach(MQTT_RECONNECT_DELAY, [this]() {
+      reconnectTimer.attach<MqttPublisher*>(MQTT_RECONNECT_DELAY, [](MqttPublisher* publisher) {
         if (WiFi.isConnected()) {
-          this->connect();          
+          publisher->connect();          
         }
-      });
-#endif
+      }, this);
     });
   }
 };

--- a/src/MqttPublisher.h
+++ b/src/MqttPublisher.h
@@ -152,8 +152,14 @@ public:
     this->reconnectTimer.detach();
   }
 
+  void setNetworkConnected(bool connected)
+  {
+    networkConnected = connected;
+  }
+
 private:
   bool connected = false;
+  bool networkConnected = false;
   MqttConfig config;
   AsyncMqttClient client;
   Ticker reconnectTimer;
@@ -204,7 +210,8 @@ private:
       this->connected = false;
       DEBUG(F("MQTT: Disconnected. Reason: %d."), reason);
       reconnectTimer.attach<MqttPublisher*>(MQTT_RECONNECT_DELAY, [](MqttPublisher* publisher) {
-        if (WiFi.isConnected()) {
+        DEBUG(F("MQTT: Trying to reconnect, Wifi.isConnected = %d"), WiFi.isConnected());
+        if (WiFi.isConnected() || publisher->networkConnected) {
           publisher->connect();          
         }
       }, this);

--- a/src/config.h
+++ b/src/config.h
@@ -13,14 +13,37 @@ const char *CONFIG_VERSION = "1.0.2";
 const char *WIFI_AP_SSID = "SMLReader";
 const char *WIFI_AP_DEFAULT_PASSWORD = "";
 
+#define ESP32_ETH
+
 static const SensorConfig SENSOR_CONFIGS[] = {
-    {.pin = D2,
+    {.uart = &Serial1,
+     .pin = 2,
      .name = "1",
      .numeric_only = false,
-     .status_led_enabled = true,
+     .status_led_enabled = false,
      .status_led_inverted = true,
-     .status_led_pin = LED_BUILTIN,
-     .interval = 0}};
+     .status_led_pin = 0,
+     .interval = 0},
+
+    {.uart = nullptr,
+     .pin = 36,
+     .name = "2",
+     .numeric_only = false,
+     .status_led_enabled = false,
+     .status_led_inverted = true,
+     .status_led_pin = 0,
+     .interval = 0},
+
+     {.uart = &Serial2,
+     .pin = 16,
+     .name = "3",
+     .numeric_only = false,
+     .status_led_enabled = false,
+     .status_led_inverted = true,
+     .status_led_pin = 0,
+     .interval = 0}
+
+};
 
 const uint8_t NUM_OF_SENSORS = sizeof(SENSOR_CONFIGS) / sizeof(SensorConfig);
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,7 +1,9 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#include "FormattingSerialDebug.h"
+#define ARDUINO_ARCH_ESP8266
+#include <FormattingSerialDebug.h>
+
 #include <sml/sml_file.h>
 #include <sml/sml_value.h>
 #include "unit.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,6 +93,7 @@ void OnEthernetEvent(WiFiEvent_t event)
     default:
       break;
   }
+  publisher.setNetworkConnected(eth_connected);
 }
 
 void process_message(byte *buffer, size_t len, Sensor *sensor)


### PR DESCRIPTION
Hello together,
we use ESPReader on the ESP32 POE EA (External Antenna) from Olimex. To get this working, we made the following changes:
1) Add support for Ethernet. The configuration still needs to be done with the WiFi Access Point. In our case, we remove the WiFi antenna after doing the config, so we did not disable the AP.
To enable ethernet, add #define ESP32_ETH in config.h or via platformio.ini
2) Add support for hardware RS-232 of the ESP32.
3) Add a work around for MicroDebug to work well on the ESP32.